### PR TITLE
Publish forked image/chart to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    env:
+      GHCR_OWNER: erauner12
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +43,7 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ env.GHCR_OWNER }}/mergeable
           tags: |
             type=raw,value=${{ github.sha }}
             type=raw,value=latest
@@ -57,14 +59,16 @@ jobs:
             VITE_COMMIT_SHA=${{ github.sha }}
       - name: Sign image
         run: |
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  ghcr.io/${{ github.repository }}:${{ github.sha }}
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  ghcr.io/${{ github.repository }}:latest
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  ghcr.io/${{ env.GHCR_OWNER }}/mergeable:${{ github.sha }}
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  ghcr.io/${{ env.GHCR_OWNER }}/mergeable:latest
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
   helm:
     runs-on: ubuntu-latest
     needs: [docker]
+    env:
+      GHCR_OWNER: erauner12
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,6 +88,6 @@ jobs:
           value: ${{ github.sha }}
           commitChange: false
       - name: Package chart
-        run: helm package helm/mergeable --version 0.0.${{ github.run_number }} --destination dist
+        run: helm package helm/mergeable --version 0.0.${{ github.run_number }} --app-version ${{ github.sha }} --destination dist
       - name: Push chart
-        run: helm push dist/*.tgz oci://ghcr.io/pvcnt/helm
+        run: helm push dist/*.tgz oci://ghcr.io/${{ env.GHCR_OWNER }}/helm

--- a/helm/mergeable/README.md
+++ b/helm/mergeable/README.md
@@ -4,6 +4,11 @@
 
 A Helm chart for Mergeable, a better inbox for GitHub pull requests.
 
+## Installation
+
+If you built the chart from this fork, install with:
+`helm install mergeable oci://ghcr.io/erauner12/helm/mergeable --version 0.0.<run-id>`
+
 ## Maintainers
 
 | Name  | Email | Url |
@@ -18,7 +23,7 @@ A Helm chart for Mergeable, a better inbox for GitHub pull requests.
 | env                                | object | `{}`                        |             |
 | fullnameOverride                   | string | `""`                        |             |
 | image.pullPolicy                   | string | `"Always"`                  |             |
-| image.repository                   | string | `"ghcr.io/pvcnt/mergeable"` |             |
+| image.repository                   | string | `"ghcr.io/erauner12/mergeable"` |             |
 | image.tag                          | string | `"latest"`                  |             |
 | imagePullSecrets                   | list   | `[]`                        |             |
 | ingress.annotations                | object | `{}`                        |             |

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/pvcnt/mergeable
+  repository: ghcr.io/erauner12/mergeable
   pullPolicy: Always
   # Tag is overridden by CI before publishing the Helm Chart.
   tag: "latest"


### PR DESCRIPTION
## Summary
- publish Docker image under personal GHCR namespace
- push Helm chart to personal GHCR namespace
- document custom installation instructions
- default Helm chart values use personal registry

## Testing
- `pnpm -v` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683b36584e388322af76481524e87904