### PR TITLE
wip handle resolved threads

### DIFF
--- a/apps/web/src/components/PromptCopyDialog.tsx
+++ b/apps/web/src/components/PromptCopyDialog.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   Checkbox,
   Classes,
   Collapse,
@@ -10,11 +11,10 @@ import {
   Icon,
   Intent,
   Tooltip,
-  ButtonGroup,
 } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 // import React, { useState, useEffect, useMemo } from "react"; // REMOVED React default import
-import { useState, useEffect, useMemo } from "react"; // ADDED (React default import removed)
+import { useEffect, useMemo, useState } from "react"; // ADDED (React default import removed)
 import type { PromptBlock } from "../lib/repoprompt"; // REMOVED DiffBlockInput, CommentBlockInput, DiffOptions
 import { formatPromptBlock } from "../lib/repoprompt"; // Import formatter
 import styles from "./PromptCopyDialog.module.scss";
@@ -70,33 +70,55 @@ export function PromptCopyDialog({
   repoPromptUrl,
   onOpenRepoPrompt,
 }: PromptCopyDialogProps) {
-  const [openCollapsible, setOpenCollapsible] = useState<Record<string, boolean>>({}); // Use block.id as key
+  const [openCollapsible, setOpenCollapsible] = useState<
+    Record<string, boolean>
+  >({}); // Use block.id as key
   const [copyStatus, setCopyStatus] = useState<CopyState | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [userText, setUserText] = useState<string>(""); // ADDED userText state
 
   // Initialize selectedIds and openCollapsible when dialog opens or blocks/initial selections change
   useEffect(() => {
     if (isOpen) {
-      const initialCollapseState: Record<string, boolean> = {};
-      const defaultSelected = new Set<string>();
+      const finalSelectedIds = new Set<string>();
+      const finalOpenCollapsible: Record<string, boolean> = {};
 
       blocks.forEach((block) => {
-        // Default to collapsed if content is long, otherwise open
-        const content = block.kind === "diff" ? block.patch : block.commentBody;
-        initialCollapseState[block.id] = content.length < 1000;
-
-        if (initialSelectedBlockIds?.has(block.id)) {
-          defaultSelected.add(block.id);
-        } else if (block.id.startsWith("pr-details")) { // Always select PR details by default
-             defaultSelected.add(block.id);
+        if (block.kind === "comment" && block.threadId) {
+          // This is a comment thread block
+          const isResolved = block.resolved === true;
+          if (!isResolved) {
+            // Default: select if unresolved
+            finalSelectedIds.add(block.id);
+          }
+          finalOpenCollapsible[block.id] = !isResolved; // Default: open if unresolved, collapse if resolved
+        } else {
+          // Non-thread blocks (PR details, general comments, diffs)
+          finalSelectedIds.add(block.id); // Default: select
+          finalOpenCollapsible[block.id] = true; // Default: open (expanded)
         }
-        // Other comment blocks are not selected by default unless specified by initialSelectedBlockIds
       });
-      setOpenCollapsible(initialCollapseState);
-      setSelectedIds(initialSelectedBlockIds || defaultSelected);
-    }
-  }, [isOpen, blocks, initialSelectedBlockIds]);
 
+      // If initialSelectedBlockIds is provided, it dictates selection.
+      // Collapse state is determined by block type/resolved status, not by initialSelectedBlockIds.
+      if (initialSelectedBlockIds !== undefined) {
+        setSelectedIds(new Set(initialSelectedBlockIds));
+      } else {
+        setSelectedIds(finalSelectedIds);
+      }
+      setOpenCollapsible(finalOpenCollapsible);
+    } else {
+      // if !isOpen
+      setUserText(""); // Existing logic to reset userText
+    }
+  }, [isOpen, blocks, initialSelectedBlockIds]); // Dependencies remain the same
+
+  // Reset userText when dialog is closed/reopened
+  useEffect(() => {
+    if (!isOpen) {
+      setUserText("");
+    }
+  }, [isOpen]);
 
   const handleCopy = async (textToCopy: string, id: string) => {
     const success = await copyTextToClipboard(textToCopy);
@@ -110,11 +132,11 @@ export function PromptCopyDialog({
   };
 
   const toggleCollapse = (blockId: string) => {
-    setOpenCollapsible(prev => ({ ...prev, [blockId]: !prev[blockId] }));
+    setOpenCollapsible((prev) => ({ ...prev, [blockId]: !prev[blockId] }));
   };
 
   const toggleSelected = (blockId: string) => {
-    setSelectedIds(prev => {
+    setSelectedIds((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(blockId)) {
         newSet.delete(blockId);
@@ -127,29 +149,55 @@ export function PromptCopyDialog({
 
   const currentSelectedText = useMemo(() => {
     return blocks
-      .filter(block => selectedIds.has(block.id))
-      .map(block => formatPromptBlock(block)) // Use the formatter
+      .filter((block) => selectedIds.has(block.id))
+      .map((block) => formatPromptBlock(block)) // Use the formatter
       .join("\n")
       .trimEnd();
   }, [blocks, selectedIds]);
-  
+
   const renderBlockContent = (block: PromptBlock) => {
     if (block.kind === "diff") {
-      return <pre className={`${Classes.CODE_BLOCK} ${styles.codeBlock}`}>{block.patch}</pre>;
+      return (
+        <pre className={`${Classes.CODE_BLOCK} ${styles.codeBlock}`}>
+          {block.patch}
+        </pre>
+      );
     }
     // block.kind === "comment"
     return (
       <div className={styles.commentBlockContent}>
         <div className={styles.commentMeta}>
-          {block.authorAvatarUrl && <img src={block.authorAvatarUrl} alt={block.author} className={styles.avatar} />}
-          <span><strong>@{block.author}</strong> · {new Date(block.timestamp).toLocaleDateString("en-CA", { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' })}</span>
-          {block.filePath && <span className={styles.filePath}> ({block.filePath}{block.line ? `:${block.line}` : ''})</span>}
+          {block.authorAvatarUrl && (
+            <img
+              src={block.authorAvatarUrl}
+              alt={block.author}
+              className={styles.avatar}
+            />
+          )}
+          <span>
+            <strong>@{block.author}</strong> ·{" "}
+            {new Date(block.timestamp).toLocaleDateString("en-CA", {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+            })}
+          </span>
+          {block.filePath && (
+            <span className={styles.filePath}>
+              {" "}
+              ({block.filePath}
+              {block.line ? `:${block.line}` : ""})
+            </span>
+          )}
         </div>
-        <pre className={`${Classes.RUNNING_TEXT} ${styles.codeBlock}`}>{block.commentBody}</pre>
+        <pre className={`${Classes.RUNNING_TEXT} ${styles.codeBlock}`}>
+          {block.commentBody}
+        </pre>
       </div>
     );
   };
-
 
   return (
     <Dialog
@@ -163,60 +211,120 @@ export function PromptCopyDialog({
     >
       <DialogBody>
         <div className={styles.scrollableContent}>
-          {blocks.map((block) => (
-            <div key={block.id} className={styles.promptBlock}>
-              <div className={styles.blockHeader}>
-                <Checkbox
-                  checked={selectedIds.has(block.id)}
-                  onChange={() => toggleSelected(block.id)}
-                  className={styles.blockCheckbox}
-                />
-                <H5>{block.header}</H5>
-                <div className={styles.blockActions}>
-                  <Tooltip content={openCollapsible[block.id] ? "Collapse" : "Expand"}>
-                    <Button
-                      minimal
-                      icon={openCollapsible[block.id] ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
-                      onClick={() => toggleCollapse(block.id)}
-                      small
-                    />
-                  </Tooltip>
-                  <Tooltip content={copyStatus?.id === block.id && copyStatus.copied ? "Copied!" : `Copy section: ${block.header.substring(0,20)}...`}>
-                    <Button
-                      minimal
-                      icon={copyStatus?.id === block.id && copyStatus.copied ? IconNames.SAVED : IconNames.CLIPBOARD}
-                      onClick={() => handleCopy(formatPromptBlock(block), block.id)} // Format individual block for copy
-                      small
-                    />
-                  </Tooltip>
-                   {! (copyStatus?.id === block.id && !copyStatus.copied) ? null : (
-                     <Tooltip content="Failed to copy" intent={Intent.DANGER}>
-                        <Icon icon={IconNames.ERROR} intent={Intent.DANGER} style={{ marginLeft: '4px' }} />
-                     </Tooltip>
-                   )}
+          {blocks.map((block) => {
+            const isResolvedThread =
+              block.kind === "comment" &&
+              block.threadId &&
+              block.resolved === true;
+
+            let checkboxElement = (
+              <Checkbox
+                checked={selectedIds.has(block.id)}
+                onChange={() => toggleSelected(block.id)}
+                className={styles.blockCheckbox}
+              />
+            );
+
+            if (isResolvedThread) {
+              checkboxElement = (
+                <Tooltip content="Thread is resolved" placement="top" minimal>
+                  {checkboxElement}
+                </Tooltip>
+              );
+            }
+
+            return (
+              <div key={block.id} className={styles.promptBlock}>
+                <div
+                  className={`${styles.blockHeader} ${isResolvedThread ? styles.resolvedHeader : ""}`}
+                >
+                  {checkboxElement}
+                  <H5>{block.header}</H5>
+                  <div className={styles.blockActions}>
+                    <Tooltip
+                      content={
+                        openCollapsible[block.id] ? "Collapse" : "Expand"
+                      }
+                    >
+                      <Button
+                        minimal
+                        icon={
+                          openCollapsible[block.id]
+                            ? IconNames.CHEVRON_UP
+                            : IconNames.CHEVRON_DOWN
+                        }
+                        onClick={() => toggleCollapse(block.id)}
+                        small
+                      />
+                    </Tooltip>
+                    <Tooltip
+                      content={
+                        copyStatus?.id === block.id && copyStatus.copied
+                          ? "Copied!"
+                          : `Copy section: ${block.header.substring(0, 20)}...`
+                      }
+                    >
+                      <Button
+                        minimal
+                        icon={
+                          copyStatus?.id === block.id && copyStatus.copied
+                            ? IconNames.SAVED
+                            : IconNames.CLIPBOARD
+                        }
+                        onClick={() =>
+                          handleCopy(formatPromptBlock(block), block.id)
+                        } // Format individual block for copy
+                        small
+                      />
+                    </Tooltip>
+                    {!(
+                      copyStatus?.id === block.id && !copyStatus.copied
+                    ) ? null : (
+                      <Tooltip content="Failed to copy" intent={Intent.DANGER}>
+                        <Icon
+                          icon={IconNames.ERROR}
+                          intent={Intent.DANGER}
+                          style={{ marginLeft: "4px" }}
+                        />
+                      </Tooltip>
+                    )}
+                  </div>
                 </div>
+                <Collapse isOpen={openCollapsible[block.id] ?? true}>
+                  {renderBlockContent(block)}
+                </Collapse>
               </div>
-              <Collapse isOpen={openCollapsible[block.id] ?? true}>
-                {renderBlockContent(block)}
-              </Collapse>
-            </div>
-          ))}
+            );
+          })}
         </div>
+        {/* ADDED Composer TextArea */}
       </DialogBody>
       <DialogFooter
         actions={
           <ButtonGroup minimal={false} large={false}>
             <Button
-              icon={copyStatus?.id === 'all_selected' && copyStatus.copied ? IconNames.SAVED : IconNames.CLIPBOARD}
-              text={copyStatus?.id === 'all_selected' && copyStatus.copied ? "Copied!" : "Copy Selected"}
-              onClick={() => handleCopy(currentSelectedText, 'all_selected')}
+              icon={
+                copyStatus?.id === "all_selected" && copyStatus.copied
+                  ? IconNames.SAVED
+                  : IconNames.CLIPBOARD
+              }
+              text={
+                copyStatus?.id === "all_selected" && copyStatus.copied
+                  ? "Copied!"
+                  : "Copy Selected"
+              }
+              onClick={() => handleCopy(currentSelectedText, "all_selected")}
               disabled={selectedIds.size === 0} // Disable if nothing selected
               rightIcon={
-                (copyStatus?.id === 'all_selected' && !copyStatus.copied) ?
-                <Tooltip content="Failed to copy" intent={Intent.DANGER} placement="top">
-                  <Icon icon={IconNames.ERROR} intent={Intent.DANGER} />
-                </Tooltip>
-                : undefined
+                copyStatus?.id === "all_selected" && !copyStatus.copied ? (
+                  <Tooltip
+                    content="Failed to copy"
+                    intent={Intent.DANGER}
+                    placement="top"
+                  >
+                    <Icon icon={IconNames.ERROR} intent={Intent.DANGER} />
+                  </Tooltip>
+                ) : undefined
               }
             />
             <Button
@@ -225,7 +333,7 @@ export function PromptCopyDialog({
               disabled={!repoPromptUrl}
               onClick={() => {
                 if (repoPromptUrl) {
-                  window.open(repoPromptUrl, '_blank');
+                  window.open(repoPromptUrl, "_blank");
                   onOpenRepoPrompt?.(currentSelectedText); // Pass current selected text
                 }
               }}

--- a/apps/web/src/lib/github/client.ts
+++ b/apps/web/src/lib/github/client.ts
@@ -50,6 +50,12 @@ export type PullRequestCommit =
 type ReviewCommentItem =
   Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"]["data"][number];
 
+// Extended type for the response of fetching a single pull request comment, including 'is_resolved'
+type PullRequestCommentSingleWithResolution =
+  Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"]["data"] & {
+    is_resolved?: boolean;
+  };
+
 export type Endpoint = {
   auth: string;
   baseUrl: string;
@@ -351,7 +357,7 @@ export class DefaultGitHubClient implements GitHubClient {
           .then((response) => {
             // Assuming 'is_resolved' is available on response.data as per plan.
             // Standard Octokit types do not include this for this endpoint.
-            return (response.data as any)?.is_resolved === true;
+            return (response.data as PullRequestCommentSingleWithResolution)?.is_resolved === true;
           })
           .catch((err) => {
             console.warn(

--- a/apps/web/src/lib/github/client.ts
+++ b/apps/web/src/lib/github/client.ts
@@ -301,20 +301,15 @@ export class DefaultGitHubClient implements GitHubClient {
     // Helper: derive a stable key representing a single conversation thread
     // This new keying logic ensures that comments are grouped by their actual conversation root,
     // using `in_reply_to_id` if available, or the comment's own `id` if it's a new thread root.
-    // `pull_request_review_id` is used as an optional discriminator.
+    // GitHub comment IDs are unique within a repository, so the rootId is sufficient.
     // This works for both comments within a formal review and standalone inline comment threads.
     function getThreadKey(rc: ReviewCommentItem): string {
       // Root of the conversation: either the comment we reply to, or ourselves.
+      // GitHub comment IDs are unique within the repository.
       const rootId = rc.in_reply_to_id ?? rc.id;
-
-      // Optional discriminator: include review-id when present to avoid
-      // theoretical collisions across *different* reviews that happen to reuse
-      // the same root-id (extremely rare but free insurance).
-      return rc.pull_request_review_id
-        ? `${rootId}:${rc.pull_request_review_id}`
-        : `${rootId}`;
+      return String(rootId);
     }
-
+    
     // Only include comments with a user (should always be true)
     const validReviewComments = reviewCommentsResponse.filter(
       (rc) => !!rc.user,

--- a/apps/web/src/lib/github/client.ts
+++ b/apps/web/src/lib/github/client.ts
@@ -102,6 +102,7 @@ export async function getPullRequestDiff(
 export class DefaultGitHubClient implements GitHubClient {
   private octokits: Record<string, Octokit> = {};
   private commentCache: Map<string, Promise<CommentBlockInput[]>> = new Map();
+  private threadResolutionCache: Map<string, Promise<boolean>> = new Map(); // ADDED cache for thread resolution
 
   private getOctokit(endpoint: Endpoint): Octokit {
     if (!this.octokits[endpoint.auth]) {
@@ -201,7 +202,8 @@ export class DefaultGitHubClient implements GitHubClient {
     const octokit = this.getOctokit(endpoint);
 
     // Fetch issue comments
-    const issueCommentsResponse = await octokit.paginate( // Renamed for clarity
+    const issueCommentsResponse = await octokit.paginate(
+      // Renamed for clarity
       octokit.rest.issues.listComments,
       {
         owner,
@@ -212,15 +214,20 @@ export class DefaultGitHubClient implements GitHubClient {
     );
 
     // Fetch pull request reviews
-    const reviewsResponse = await octokit.paginate(octokit.rest.pulls.listReviews, { // Renamed for clarity
-      owner,
-      repo,
-      pull_number: number,
-      per_page: 100,
-    });
+    const reviewsResponse = await octokit.paginate(
+      octokit.rest.pulls.listReviews,
+      {
+        // Renamed for clarity
+        owner,
+        repo,
+        pull_number: number,
+        per_page: 100,
+      },
+    );
 
     // Fetch pull request review comments
-    const reviewCommentsResponse = await octokit.paginate( // Renamed for clarity
+    const reviewCommentsResponse = await octokit.paginate(
+      // Renamed for clarity
       octokit.rest.pulls.listReviewComments,
       {
         owner,
@@ -249,7 +256,8 @@ export class DefaultGitHubClient implements GitHubClient {
 
     // 2. Reviews (summary comments)
     for (const r of reviewsResponse) {
-      if (r.body && r.submitted_at) { // Only include reviews that have a body text and a submission timestamp
+      if (r.body && r.submitted_at) {
+        // Only include reviews that have a body text and a submission timestamp
         allCommentBlocks.push({
           id: `review-${r.id.toString()}`, // Ensure unique ID namespace
           kind: "comment",
@@ -264,70 +272,127 @@ export class DefaultGitHubClient implements GitHubClient {
     }
 
     // 3. Pull request review comments (comments on diffs / threads)
-    // Group review comments by thread
-    const threads = new Map<string, {
-        path: string;
-        line: number; // Line in the diff to which the thread pertains
-        diffHunk?: string;
-        commentsData: IndividualCommentData[];
-    }>();
+    // Group review comments by thread and fetch/cached resolution status
 
-    for (const rc of reviewCommentsResponse) {
-      if (!rc.user) continue; // Should ideally not happen
+    // Helper: groupBy function
+    function groupBy<T, K extends string | number>(
+      arr: T[],
+      keyFn: (item: T) => K,
+    ): Record<K, T[]> {
+      const result = {} as Record<K, T[]>;
+      for (const item of arr) {
+        const key = keyFn(item);
+        if (!result[key]) result[key] = [];
+        result[key].push(item);
+      }
+      return result;
+    }
 
+    // Helper: get thread key for a review comment
+    function getThreadKey(rc: any): string {
       // Use pull_request_review_id as the primary key for threading.
       // If null (e.g. outdated comment, or single comment not part of a review),
       // use the comment's own ID to treat it as a distinct "thread".
       // Prefix with "comment-" to avoid collision if rc.id could be same as a review_id.
-      const threadKey = rc.pull_request_review_id ? String(rc.pull_request_review_id) : `comment-${rc.id}`;
-      
-      let threadData = threads.get(threadKey);
-      if (!threadData) {
-        threadData = {
-          path: rc.path,
-          // `line` is the line in the diff. `original_line` is in the file.
-          // For header "THREAD ON path#L<line>", `line` (in diff) is appropriate with `diff_hunk`.
-          line: rc.line ?? (rc.original_line ?? 0), // Fallback for line
-          diffHunk: rc.diff_hunk ?? undefined,
-          commentsData: [],
-        };
-        threads.set(threadKey, threadData);
-      }
-
-      // In case the first comment didn't have a diff_hunk but a subsequent one in the same thread does.
-      // This assumes diff_hunk is consistent or the first one is representative.
-      if (!threadData.diffHunk && rc.diff_hunk) {
-        threadData.diffHunk = rc.diff_hunk;
-      }
-      // If path or line differs for comments supposedly in the same thread_id, take the first one.
-      // This shouldn't happen for well-formed threads.
-
-      threadData.commentsData.push({
-        id: rc.id.toString(),
-        commentBody: rc.body ?? "",
-        author: rc.user.login,
-        authorAvatarUrl: rc.user.avatar_url,
-        timestamp: rc.created_at,
-      });
+      return rc.pull_request_review_id
+        ? String(rc.pull_request_review_id)
+        : `comment-${rc.id}`;
     }
 
-    // Process grouped threads
-    for (const [threadKey, data] of threads.entries()) {
-      if (data.commentsData.length === 0) continue; // Skip if a thread somehow ended up empty
+    // Only include comments with a user (should always be true)
+    const validReviewComments = reviewCommentsResponse.filter(
+      (rc) => !!rc.user,
+    );
 
-      // Sort comments within the thread by timestamp (chronological)
-      data.commentsData.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-      
+    const groupedByThreadKey = groupBy(validReviewComments, getThreadKey);
+
+    for (const threadKey in groupedByThreadKey) {
+      const commentsInThreadGroup = groupedByThreadKey[threadKey];
+      if (!commentsInThreadGroup || commentsInThreadGroup.length === 0) {
+        continue;
+      }
+
+      // Sort comments chronologically within the thread
+      commentsInThreadGroup.sort(
+        (a, b) =>
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+      );
+
+      const headComment = commentsInThreadGroup[0]; // The first comment chronologically establishes path, line, hunk
+
+      const path = headComment.path;
+      // Use line in diff, fallback to original_line in commit, then 0
+      const line = headComment.line ?? headComment.original_line ?? 0;
+      const diffHunk = headComment.diff_hunk ?? undefined;
+
+      // Fetch resolution status for the thread (identified by headComment.id of its first comment)
+      // Note: Standard GitHub REST API for a single comment does not provide 'is_resolved'.
+      // This implementation follows the user's plan, assuming this call yields resolution status.
+      let resolved = false; // Default to unresolved
+      const commentIdForThreadMeta = parseInt(headComment.id); // API expects number
+
+      // Use threadKey for caching resolution as it represents the group.
+      // headComment.id should be stable for a given threadKey.
+      const cacheKeyForResolution = threadKey;
+
+      if (this.threadResolutionCache.has(cacheKeyForResolution)) {
+        resolved = await this.threadResolutionCache.get(cacheKeyForResolution)!;
+      } else {
+        const resolutionPromise = octokit
+          .request("GET /repos/{owner}/{repo}/pulls/comments/{comment_id}", {
+            owner,
+            repo,
+            comment_id: commentIdForThreadMeta, // Use the ID of one comment in the thread
+          })
+          .then((response) => {
+            // Assuming 'is_resolved' is available on response.data as per plan.
+            // Standard Octokit types do not include this for this endpoint.
+            return (response.data as any)?.is_resolved === true;
+          })
+          .catch((err) => {
+            console.warn(
+              `Failed to fetch thread metadata for threadKey ${threadKey} (comment ${commentIdForThreadMeta}):`,
+              err,
+            );
+            return false; // Default to unresolved on error
+          });
+        this.threadResolutionCache.set(
+          cacheKeyForResolution,
+          resolutionPromise,
+        );
+        // Ensure cache is cleaned up if the promise itself rejects, not just its chained .then/.catch
+        resolutionPromise.catch(() => {
+          if (
+            this.threadResolutionCache.get(cacheKeyForResolution) ===
+            resolutionPromise
+          ) {
+            this.threadResolutionCache.delete(cacheKeyForResolution);
+          }
+        });
+        resolved = await resolutionPromise;
+      }
+
+      const individualCommentsData: IndividualCommentData[] =
+        commentsInThreadGroup.map((rc) => ({
+          id: rc.id.toString(),
+          commentBody: rc.body ?? "",
+          // rc.user is guaranteed to be non-null here due to the filter above
+          author: rc.user.login,
+          authorAvatarUrl: rc.user.avatar_url,
+          timestamp: rc.created_at,
+        }));
+
       const threadBlock = makeThreadBlock(
-        threadKey,
-        data.path,
-        data.line,
-        data.diffHunk,
-        data.commentsData
+        threadKey, // The key used for grouping (e.g., path:diff_hunk)
+        path,
+        line,
+        diffHunk,
+        individualCommentsData, // Sorted
+        resolved, // Pass resolved status
       );
       allCommentBlocks.push(threadBlock);
     }
-    
+
     // Sort all blocks (issue comments, review summaries, thread blocks) by their primary timestamp
     allCommentBlocks.sort(
       (a, b) =>

--- a/apps/web/src/lib/github/client.ts
+++ b/apps/web/src/lib/github/client.ts
@@ -46,6 +46,10 @@ const MyOctokit = Octokit.plugin(throttling);
 export type PullRequestCommit =
   Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["response"]["data"][number];
 
+// Type for individual review comments from the list endpoint
+type ReviewCommentItem =
+  Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"]["data"][number];
+
 export type Endpoint = {
   auth: string;
   baseUrl: string;
@@ -289,7 +293,7 @@ export class DefaultGitHubClient implements GitHubClient {
     }
 
     // Helper: get thread key for a review comment
-    function getThreadKey(rc: any): string {
+    function getThreadKey(rc: ReviewCommentItem): string {
       // Use pull_request_review_id as the primary key for threading.
       // If null (e.g. outdated comment, or single comment not part of a review),
       // use the comment's own ID to treat it as a distinct "thread".
@@ -329,7 +333,7 @@ export class DefaultGitHubClient implements GitHubClient {
       // Note: Standard GitHub REST API for a single comment does not provide 'is_resolved'.
       // This implementation follows the user's plan, assuming this call yields resolution status.
       let resolved = false; // Default to unresolved
-      const commentIdForThreadMeta = parseInt(headComment.id); // API expects number
+      const commentIdForThreadMeta = headComment.id; // API expects number, headComment.id is already a number
 
       // Use threadKey for caching resolution as it represents the group.
       // headComment.id should be stable for a given threadKey.

--- a/apps/web/src/lib/github/commentThreads.ts
+++ b/apps/web/src/lib/github/commentThreads.ts
@@ -32,7 +32,8 @@ export function makeThreadBlock(
   path: string,
   line: number,
   hunk: string | undefined,
-  comments: IndividualCommentData[] // Sorted individual comments
+  comments: IndividualCommentData[], // Sorted individual comments
+  resolved: boolean,
 ): CommentBlockInput {
   if (comments.length === 0) {
     // This case should ideally be prevented by the caller
@@ -56,6 +57,7 @@ export function makeThreadBlock(
         diffHunk: hunk,
         filePath: path,
         line: line,
+        resolved: false, // Default for empty/error case
     };
   }
 
@@ -75,5 +77,6 @@ export function makeThreadBlock(
     diffHunk: hunk,
     filePath: path,
     line: line,
+    resolved: resolved,
   };
 }

--- a/apps/web/src/lib/github/commentThreads.ts
+++ b/apps/web/src/lib/github/commentThreads.ts
@@ -28,7 +28,7 @@ export function formatSingleComment(comment: IndividualCommentData): string {
 }
 
 export function makeThreadBlock(
-  threadKey: string, // The original key used for grouping (e.g., review_id or comment-id)
+  threadKey: string, // The key representing the conversation thread, typically derived from the root comment's ID (e.g., `in_reply_to_id ?? id`) and optionally a `pull_request_review_id`.
   path: string,
   line: number,
   hunk: string | undefined,

--- a/apps/web/src/lib/repoprompt.ts
+++ b/apps/web/src/lib/repoprompt.ts
@@ -31,6 +31,7 @@ export interface CommentBlockInput {
   line?: number; // For threads
   threadId?: string; // new – PR review thread (undefined for issue comments)
   diffHunk?: string; // new – raw hunk text from the API
+  resolved?: boolean; // ← NEW (undefined = not a code-thread or resolution unknown, false = unresolved, true = resolved)
 }
 
 // Updated: DiffBlockInput to include 'kind'

--- a/apps/web/tests/lib/github/client.test.ts
+++ b/apps/web/tests/lib/github/client.test.ts
@@ -5,6 +5,12 @@ import {
 } from "../../../src/lib/github/client"; // Ensure Endpoint is imported if not already
 import { setupRecording } from "./polly.js";
 
+// Helper function to count actual comments in a formatted thread body
+function countComments(body: string): number {
+  // each top-level comment starts with "> _@…"
+  return (body.match(/^> _@/gm) ?? []).length;
+}
+
 // Remove TEMP DEBUG console.log
 // console.log("GH_TOKEN visible inside test:", !!process.env.GH_TOKEN);
 
@@ -71,27 +77,54 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
   };
   (client as any).getOctokit = vi.fn().mockReturnValue(mockOctokit);
 
-  // Mock listReviewComments to return two threads
-  const commentIdUnresolved = 101;
-  const commentIdResolved = 202;
+  // Mock listReviewComments
+  // Thread 1: two comments, same pull_request_review_id. Last one determines resolution.
+  // With new logic, these will be grouped by in_reply_to_id if present, or by id if root.
+  // Here, comment 101 is root, 202 replies to 101. Both part of review 777.
+  // ThreadKey will be "101:777".
+  const reviewIdForMainThread = 777;
+  const commentIdMainThreadUnresolvedPart = 101; // Root comment of the main thread
+  const commentIdMainThreadResolvedPart = 202; // Reply comment in the main thread
+
+  // Thread 2: single comment, different pull_request_review_id, unresolved.
+  // ThreadKey will be "303:888".
+  const reviewIdForSecondThread = 888;
+  const commentIdSecondThread = 303;
+
   mockOctokit.paginate.mockImplementation(async (method: any, _params: any) => {
     if (method === mockOctokit.rest.pulls.listReviewComments) {
       return [
+        // Comments for Main Thread (will be grouped by rootId:reviewId)
         {
-          id: commentIdUnresolved,
+          id: commentIdMainThreadUnresolvedPart, // 101
+          pull_request_review_id: reviewIdForMainThread, // 777
+          in_reply_to_id: null, // This is the root comment
           path: "file1.ts",
-          diff_hunk: "hunk1",
-          body: "unresolved comment",
+          diff_hunk: "hunk for main thread",
+          body: "main thread - unresolved part",
           user: { login: "userA", avatar_url: "" },
-          created_at: new Date().toISOString(),
+          created_at: new Date(2024, 0, 1, 10, 0, 0).toISOString(), // Earlier
         },
         {
-          id: commentIdResolved,
-          path: "file2.ts",
-          diff_hunk: "hunk2",
-          body: "resolved comment",
+          id: commentIdMainThreadResolvedPart, // 202
+          pull_request_review_id: reviewIdForMainThread, // 777 (same review)
+          in_reply_to_id: commentIdMainThreadUnresolvedPart, // 101 (reply to the first comment)
+          path: "file1.ts", // Same path
+          diff_hunk: "hunk for main thread", // Same hunk
+          body: "main thread - resolved part",
           user: { login: "userB", avatar_url: "" },
-          created_at: new Date().toISOString(),
+          created_at: new Date(2024, 0, 1, 10, 5, 0).toISOString(), // Later
+        },
+        // Comment for Second Thread (distinct)
+        {
+          id: commentIdSecondThread, // 303
+          pull_request_review_id: reviewIdForSecondThread, // 888
+          in_reply_to_id: null, // This is a root comment for its own thread
+          path: "file2.ts",
+          diff_hunk: "hunk for second thread",
+          body: "second thread - unresolved",
+          user: { login: "userC", avatar_url: "" },
+          created_at: new Date(2024, 0, 1, 11, 0, 0).toISOString(),
         },
       ];
     }
@@ -99,24 +132,38 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
   });
 
   // Mock the thread resolution calls
-  mockOctokit.request.mockImplementation(async (route: string, requestParams?: { owner?: string, repo?: string, comment_id?: number }) => {
-    if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
-      if (requestParams && typeof requestParams.comment_id === 'number') {
-        // Using literal values directly for comparison
-        if (requestParams.comment_id === 101) {
-          return { data: { is_resolved: false } }; // Mock unresolved
+  // The client will call this for the *last* comment of each grouped thread.
+  mockOctokit.request.mockImplementation(
+    async (
+      route: string,
+      requestParams?: { owner?: string; repo?: string; comment_id?: number },
+    ) => {
+      if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
+        if (requestParams && typeof requestParams.comment_id === "number") {
+          // For Main Thread, it will query with ID 202 (last comment)
+          if (requestParams.comment_id === commentIdMainThreadResolvedPart) {
+            // 202
+            return { data: { is_resolved: true } };
+          }
+          // For Second Thread, it will query with ID 303
+          if (requestParams.comment_id === commentIdSecondThread) {
+            // 303
+            return { data: { is_resolved: false } };
+          }
+          // Fallback for any other IDs, like 101 if it were (incorrectly) queried
+          if (requestParams.comment_id === commentIdMainThreadUnresolvedPart) {
+            // 101
+            return { data: { is_resolved: false } };
+          }
+          return {
+            data: { message: `unknown comment_id ${requestParams.comment_id}` },
+          };
         }
-        if (requestParams.comment_id === 202) {
-          return { data: { is_resolved: true } }; // Mock resolved
-        }
-        // If comment_id is present but doesn't match known IDs
-        return { data: { message: `unknown comment_id ${requestParams.comment_id}` } };
+        return { data: { message: "bad params for comment_id route" } };
       }
-      // If params or params.comment_id is missing or not a number
-      return { data: { message: "bad params for comment_id route" } };
-    }
-    return { data: { message: "fallback_route_in_mock" } };
-  });
+      return { data: { message: "fallback_route_in_mock" } };
+    },
+  );
 
   const comments = await client.fetchPullComments(
     testEndpoint,
@@ -125,38 +172,140 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
     prNumber,
   );
 
-  const unresolvedThreadBlock = comments.find(
-    (c) =>
-      c.kind === "comment" &&
-      c.threadId &&
-      c.commentBody.includes("unresolved comment"),
+  // Expect two thread blocks because we have two distinct pull_request_review_id values
+  const threadBlocks = comments.filter(
+    (c) => c.kind === "comment" && c.threadId,
   );
-  const resolvedThreadBlock = comments.find(
-    (c) =>
-      c.kind === "comment" &&
-      c.threadId &&
-      c.commentBody.includes("resolved comment"),
+  expect(threadBlocks.length).toBe(2); // Main thread (2 comments) + Second thread (1 comment)
+
+  const mainThreadBlock = threadBlocks.find(
+    // The body will contain both comments, check for the last comment's body part
+    (c) => c.commentBody.includes("main thread - resolved part") && c.commentBody.includes("main thread - unresolved part"),
+  );
+  const secondThreadBlock = threadBlocks.find((c) =>
+    c.commentBody.includes("second thread - unresolved"),
   );
 
-  expect(unresolvedThreadBlock).toBeDefined();
-  expect(unresolvedThreadBlock?.resolved).toBe(false);
-  expect(resolvedThreadBlock).toBeDefined();
-  expect(resolvedThreadBlock?.resolved).toBe(true);
+  expect(mainThreadBlock).toBeDefined();
+  // Verify that the main thread block contains two formatted comments
+  expect(countComments(mainThreadBlock!.commentBody)).toBe(2);
+  expect(mainThreadBlock?.resolved).toBe(true); // This thread should be resolved (based on last comment 202)
+
+  expect(secondThreadBlock).toBeDefined();
+  expect(secondThreadBlock?.resolved).toBe(false); // This thread should be unresolved
 
   // Test caching of thread resolution
-  // Call again, ensure octokit.request for resolution is not called for cached keys
   mockOctokit.request.mockClear();
   await client.fetchPullComments(testEndpoint, owner, repo, prNumber);
-
-  // Check that the specific 'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}' was not called again for these comment_ids
-  // This check is a bit fragile as it depends on the exact calls.
-  // A more robust way would be to check if the promise from cache was used.
-  // For simplicity, checking call count for the specific route:
   const resolutionCalls = mockOctokit.request.mock.calls.filter(
     (call) =>
       call[0] === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}",
   );
-  expect(resolutionCalls.length).toBe(0); // Should be 0 if cache worked for both threads
+  expect(resolutionCalls.length).toBe(0);
+});
+
+test("groups comments by in_reply_to_id when review_id is null", async () => {
+  const client = new DefaultGitHubClient();
+  const testEndpoint: GitHubEndpoint = {
+    auth: process.env.GH_TOKEN ?? "ghp_token",
+    baseUrl: "https://api.github.com",
+  };
+  const owner = "test-owner";
+  const repo = "test-repo";
+  const prNumber = 2; // Use a different PR number or ensure mocks are distinct
+
+  const mockOctokit = {
+    paginate: vi.fn(),
+    request: vi.fn(),
+    rest: {
+      issues: { listComments: vi.fn() },
+      pulls: { listReviews: vi.fn(), listReviewComments: vi.fn() },
+    },
+  };
+  (client as any).getOctokit = vi.fn().mockReturnValue(mockOctokit);
+  (client as any).commentCache.clear(); // Clear cache for this test
+  (client as any).threadResolutionCache.clear(); // Clear resolution cache
+
+  const rootCommentId = 501;
+  const replyCommentId1 = 502;
+  const replyCommentId2 = 503; // This will be the last comment, used for resolution check
+
+  mockOctokit.paginate.mockImplementation(async (method: any, _params: any) => {
+    if (method === mockOctokit.rest.pulls.listReviewComments) {
+      return [
+        {
+          id: rootCommentId, // 501
+          pull_request_review_id: null,
+          in_reply_to_id: null,
+          path: "file.ts",
+          diff_hunk: "diff hunk for inline thread",
+          body: "Root comment of inline thread",
+          user: { login: "userX", avatar_url: "" },
+          created_at: new Date(2024, 1, 1, 10, 0, 0).toISOString(),
+          line: 10, // Ensure line info is present
+        },
+        {
+          id: replyCommentId1, // 502
+          pull_request_review_id: null,
+          in_reply_to_id: rootCommentId, // 501
+          path: "file.ts",
+          diff_hunk: "diff hunk for inline thread",
+          body: "First reply in inline thread",
+          user: { login: "userY", avatar_url: "" },
+          created_at: new Date(2024, 1, 1, 10, 5, 0).toISOString(),
+          line: 10,
+        },
+        {
+          id: replyCommentId2, // 503
+          pull_request_review_id: null,
+          in_reply_to_id: rootCommentId, // 501
+          path: "file.ts",
+          diff_hunk: "diff hunk for inline thread",
+          body: "Second reply in inline thread",
+          user: { login: "userX", avatar_url: "" },
+          created_at: new Date(2024, 1, 1, 10, 10, 0).toISOString(),
+          line: 10,
+        },
+      ];
+    }
+    return []; // For other paginate calls
+  });
+
+  mockOctokit.request.mockImplementation(
+    async (
+      route: string,
+      requestParams?: { owner?: string; repo?: string; comment_id?: number },
+    ) => {
+      if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
+        if (requestParams?.comment_id === replyCommentId2) { // 503
+          return { data: { is_resolved: false } }; // Assume this thread is unresolved
+        }
+        return { data: { message: `unknown comment_id ${requestParams?.comment_id}` } };
+      }
+      return { data: { message: "fallback_route_in_mock" } };
+    },
+  );
+
+  const comments = await client.fetchPullComments(
+    testEndpoint,
+    owner,
+    repo,
+    prNumber,
+  );
+
+  const threadBlocks = comments.filter(
+    (c) => c.kind === "comment" && c.threadId,
+  );
+
+  expect(threadBlocks.length).toBe(1); // Expect one thread block for the inline comments
+
+  const inlineThreadBlock = threadBlocks[0];
+  expect(inlineThreadBlock).toBeDefined();
+  expect(countComments(inlineThreadBlock.commentBody)).toBe(3); // 3 comments in this thread
+  expect(inlineThreadBlock.resolved).toBe(false);
+  expect(inlineThreadBlock.threadId).toBe(String(rootCommentId)); // Key should be "501"
+  expect(inlineThreadBlock.filePath).toBe("file.ts");
+  expect(inlineThreadBlock.line).toBe(10);
 });
 
 test("should return viewer", async () => {

--- a/apps/web/tests/lib/github/client.test.ts
+++ b/apps/web/tests/lib/github/client.test.ts
@@ -102,15 +102,15 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
   mockOctokit.request.mockImplementation(async (route: string, requestParams?: { owner?: string, repo?: string, comment_id?: number }) => {
     if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
       if (requestParams && typeof requestParams.comment_id === 'number') {
-        const currentCommentId = requestParams.comment_id;
-        if (currentCommentId === commentIdUnresolved) {
+        // Using literal values directly for comparison
+        if (requestParams.comment_id === 101) {
           return { data: { is_resolved: false } }; // Mock unresolved
         }
-        if (currentCommentId === commentIdResolved) {
+        if (requestParams.comment_id === 202) {
           return { data: { is_resolved: true } }; // Mock resolved
         }
         // If comment_id is present but doesn't match known IDs
-        return { data: { message: `unknown comment_id ${currentCommentId}` } };
+        return { data: { message: `unknown comment_id ${requestParams.comment_id}` } };
       }
       // If params or params.comment_id is missing or not a number
       return { data: { message: "bad params for comment_id route" } };

--- a/apps/web/tests/lib/github/client.test.ts
+++ b/apps/web/tests/lib/github/client.test.ts
@@ -99,14 +99,23 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
   });
 
   // Mock the thread resolution calls
-  mockOctokit.request.mockImplementation(async (route: string, params: any) => {
+  mockOctokit.request.mockImplementation(async (route: string, requestParams?: { owner?: string, repo?: string, comment_id?: number }) => {
     if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
-      if (params.comment_id === commentIdUnresolved)
-        return { data: { is_resolved: false } }; // Mock unresolved
-      if (params.comment_id === commentIdResolved)
-        return { data: { is_resolved: true } }; // Mock resolved
+      if (requestParams && typeof requestParams.comment_id === 'number') {
+        const currentCommentId = requestParams.comment_id;
+        if (currentCommentId === commentIdUnresolved) {
+          return { data: { is_resolved: false } }; // Mock unresolved
+        }
+        if (currentCommentId === commentIdResolved) {
+          return { data: { is_resolved: true } }; // Mock resolved
+        }
+        // If comment_id is present but doesn't match known IDs
+        return { data: { message: `unknown comment_id ${currentCommentId}` } };
+      }
+      // If params or params.comment_id is missing or not a number
+      return { data: { message: "bad params for comment_id route" } };
     }
-    return { data: {} };
+    return { data: { message: "fallback_route_in_mock" } };
   });
 
   const comments = await client.fetchPullComments(

--- a/apps/web/tests/lib/github/client.test.ts
+++ b/apps/web/tests/lib/github/client.test.ts
@@ -1,5 +1,8 @@
-import { expect, test } from "vitest";
-import { DefaultGitHubClient } from "../../../src/lib/github/client";
+import { expect, test, vi } from "vitest";
+import {
+  DefaultGitHubClient,
+  type Endpoint as GitHubEndpoint,
+} from "../../../src/lib/github/client"; // Ensure Endpoint is imported if not already
 import { setupRecording } from "./polly.js";
 
 // Remove TEMP DEBUG console.log
@@ -13,16 +16,153 @@ const endpoint = {
   baseUrl: "https://api.github.com",
 };
 
+test("fetchPullComments should set 'resolved' flag correctly for comment threads", async () => {
+  // This test will rely on Polly.js recordings.
+  // A new recording should be made against a PR that has:
+  // 1. A comment thread that is unresolved.
+  // 2. A comment thread that is resolved.
+  // The mock for `GET /repos/{owner}/{repo}/pulls/comments/{comment_id}` (if that's how resolution is fetched)
+  // needs to be part of this recording, returning appropriate `is_resolved` values.
+
+  const client = new DefaultGitHubClient();
+  const testEndpoint: GitHubEndpoint = {
+    auth: process.env.GH_TOKEN ?? "ghp_token",
+    baseUrl: "https://api.github.com",
+  };
+
+  // Use a real PR known to have resolved and unresolved threads for recording.
+  // Example: owner = "pvcnt", repo = "mergeable", number = <some_pr_number_for_testing_threads>
+  // For the purpose of this example, let's assume such a PR exists and Polly can record/replay it.
+  // The actual owner/repo/number would need to be set up for a real test run with Polly recording.
+  // If Polly cannot handle the dynamic nature of the new call or if `is_resolved` is not standard,
+  // this test would need more complex direct mocking of `octokit.request`.
+
+  // For now, let's assume a PR that Polly can handle.
+  // Replace with actual PR details for recording if needed.
+  const owner = "test-owner";
+  const repo = "test-repo";
+  const prNumber = 1; // Placeholder
+
+  // In a real scenario with Polly, you'd make the call:
+  // const comments = await client.fetchPullComments(testEndpoint, owner, repo, prNumber);
+
+  // For a unit test without relying on a specific live PR for recording structure,
+  // we would mock the octokit responses directly.
+  // Given Polly is in use, the expectation is that recordings will be updated/created.
+  // The assertions below assume `fetchPullComments` works as intended with the new logic.
+
+  // Example structure of what might be asserted if we had mock data:
+  // const unresolvedThread = comments.find(c => c.header.includes("UNRESOLVED_THREAD_IDENTIFIER"));
+  // const resolvedThread = comments.find(c => c.header.includes("RESOLVED_THREAD_IDENTIFIER"));
+  // expect(unresolvedThread?.resolved).toBe(false);
+  // expect(resolvedThread?.resolved).toBe(true);
+
+  // Since setting up full Polly recordings here is complex, this test serves as a placeholder
+  // for the expected testing strategy. The key is that the `resolved` flag on CommentBlockInput
+  // for threads should be correctly populated based on the (assumed) API response for thread metadata.
+  // If using direct mocks:
+  const mockOctokit = {
+    paginate: vi.fn(),
+    request: vi.fn(),
+    rest: {
+      issues: { listComments: vi.fn() },
+      pulls: { listReviews: vi.fn(), listReviewComments: vi.fn() },
+    },
+  };
+  (client as any).getOctokit = vi.fn().mockReturnValue(mockOctokit);
+
+  // Mock listReviewComments to return two threads
+  const commentIdUnresolved = 101;
+  const commentIdResolved = 202;
+  mockOctokit.paginate.mockImplementation(async (method: any, _params: any) => {
+    if (method === mockOctokit.rest.pulls.listReviewComments) {
+      return [
+        {
+          id: commentIdUnresolved,
+          path: "file1.ts",
+          diff_hunk: "hunk1",
+          body: "unresolved comment",
+          user: { login: "userA", avatar_url: "" },
+          created_at: new Date().toISOString(),
+        },
+        {
+          id: commentIdResolved,
+          path: "file2.ts",
+          diff_hunk: "hunk2",
+          body: "resolved comment",
+          user: { login: "userB", avatar_url: "" },
+          created_at: new Date().toISOString(),
+        },
+      ];
+    }
+    return []; // For other paginate calls like issueComments, reviews
+  });
+
+  // Mock the thread resolution calls
+  mockOctokit.request.mockImplementation(async (route: string, params: any) => {
+    if (route === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}") {
+      if (params.comment_id === commentIdUnresolved)
+        return { data: { is_resolved: false } }; // Mock unresolved
+      if (params.comment_id === commentIdResolved)
+        return { data: { is_resolved: true } }; // Mock resolved
+    }
+    return { data: {} };
+  });
+
+  const comments = await client.fetchPullComments(
+    testEndpoint,
+    owner,
+    repo,
+    prNumber,
+  );
+
+  const unresolvedThreadBlock = comments.find(
+    (c) =>
+      c.kind === "comment" &&
+      c.threadId &&
+      c.commentBody.includes("unresolved comment"),
+  );
+  const resolvedThreadBlock = comments.find(
+    (c) =>
+      c.kind === "comment" &&
+      c.threadId &&
+      c.commentBody.includes("resolved comment"),
+  );
+
+  expect(unresolvedThreadBlock).toBeDefined();
+  expect(unresolvedThreadBlock?.resolved).toBe(false);
+  expect(resolvedThreadBlock).toBeDefined();
+  expect(resolvedThreadBlock?.resolved).toBe(true);
+
+  // Test caching of thread resolution
+  // Call again, ensure octokit.request for resolution is not called for cached keys
+  mockOctokit.request.mockClear();
+  await client.fetchPullComments(testEndpoint, owner, repo, prNumber);
+
+  // Check that the specific 'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}' was not called again for these comment_ids
+  // This check is a bit fragile as it depends on the exact calls.
+  // A more robust way would be to check if the promise from cache was used.
+  // For simplicity, checking call count for the specific route:
+  const resolutionCalls = mockOctokit.request.mock.calls.filter(
+    (call) =>
+      call[0] === "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}",
+  );
+  expect(resolutionCalls.length).toBe(0); // Should be 0 if cache worked for both threads
+});
+
 test("should return viewer", async () => {
   const client = new DefaultGitHubClient();
 
   const viewer = await client.getViewer(endpoint);
 
   expect(viewer).toEqual({
-    user: expect.objectContaining({ // Updated assertion
+    user: expect.objectContaining({
+      // Updated assertion
       id: expect.any(String),
       name: expect.any(String),
-      avatarUrl: expect.stringMatching(/^https:\/\/avatars\.githubusercontent\.com\//),
+      avatarUrl: expect.stringMatching(
+        /^https:\/\/avatars\.githubusercontent\.com\//,
+      ),
       bot: false,
     }),
     teams: expect.any(Array), // Updated assertion
@@ -42,13 +182,15 @@ test("should search pulls", async () => {
   // portable assertions for pulls
   expect(pulls.length).toBeGreaterThan(0);
 
-  pulls.forEach(p => {
+  pulls.forEach((p) => {
     expect(p).toEqual(
       expect.objectContaining({
         id: expect.any(String),
         title: expect.any(String),
-        url: expect.stringContaining('https://github.com/'),
-        state: expect.stringMatching(/^(?:draft|pending|approved|enqueued|merged|closed)$/), // More complete regex for PullState
+        url: expect.stringContaining("https://github.com/"),
+        state: expect.stringMatching(
+          /^(?:draft|pending|approved|enqueued|merged|closed)$/,
+        ), // More complete regex for PullState
         additions: expect.any(Number),
         deletions: expect.any(Number),
         author: expect.objectContaining({
@@ -67,16 +209,18 @@ test("should search pulls", async () => {
     );
 
     // logical invariants
-    expect(new Date(p.updatedAt).getTime())
-      .toBeGreaterThanOrEqual(new Date(p.createdAt).getTime());
+    expect(new Date(p.updatedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(p.createdAt).getTime(),
+    );
     if (p.mergedAt) {
-      expect(p.state).toBe('merged');
+      expect(p.state).toBe("merged");
     }
-    if (p.closedAt && !p.mergedAt) { // If closed but not merged
-        expect(p.state).toBe('closed');
+    if (p.closedAt && !p.mergedAt) {
+      // If closed but not merged
+      expect(p.state).toBe("closed");
     }
-    if (p.state === 'enqueued') {
-        expect(p.enqueuedAt).toEqual(expect.any(String));
+    if (p.state === "enqueued") {
+      expect(p.enqueuedAt).toEqual(expect.any(String));
     }
   });
 });

--- a/apps/web/tests/lib/github/client.test.ts
+++ b/apps/web/tests/lib/github/client.test.ts
@@ -190,6 +190,7 @@ test("fetchPullComments should set 'resolved' flag correctly for comment threads
   // Verify that the main thread block contains two formatted comments
   expect(countComments(mainThreadBlock!.commentBody)).toBe(2);
   expect(mainThreadBlock?.resolved).toBe(true); // This thread should be resolved (based on last comment 202)
+  expect(mainThreadBlock?.threadId).toBe(String(commentIdMainThreadUnresolvedPart)); // Explicitly check threadId is "101"
 
   expect(secondThreadBlock).toBeDefined();
   expect(secondThreadBlock?.resolved).toBe(false); // This thread should be unresolved

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/erauner12/mergeable
   pullPolicy: Always
   # Tag is overridden by CI before publishing the Helm Chart.
-  tag: "882d7ab-20250602160335"
+  tag: "fc91a0a-20250602173234"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/erauner12/mergeable
   pullPolicy: Always
   # Tag is overridden by CI before publishing the Helm Chart.
-  tag: "bb0e48a-20250602173901"
+  tag: "3af8111-20250602174139"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/erauner12/mergeable
   pullPolicy: Always
   # Tag is overridden by CI before publishing the Helm Chart.
-  tag: "fc91a0a-20250602173234"
+  tag: "bb0e48a-20250602173901"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Resolved-aware thread folding & pre-selection

*(Feature # 1 from the previous list, delivered as a standalone slice — no refresh button yet).*

---

### 0 — Goals recap

| Case                            | Visual state on dialog open                                              | Selection state                                 |
| ------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------- |
| **Thread is *resolved***        | ▸ collapsed • grey-check icon (unchecked) • Tooltip “Thread is resolved” | **NOT** selected (excluded from initial prompt) |
| **Thread is *unresolved***      | ▾ expanded                                                               | ✅ selected (included in initial prompt)         |
| **Issue comments / PR details** | Follow current behaviour (expanded & selected).                          |                                                 |

---

### 1 — Data plumbing – surface `resolved` flag

| File                                                                          | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **`src/lib/repoprompt.ts`**                                                   | `ts export interface CommentBlockInput {   …   resolved?: boolean; // ← NEW (undefined = not a code-thread) }`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| **`src/lib/github/commentThreads.ts`**                                        | **Add param**<br>`ts export function makeThreadBlock(…, resolved: boolean, …): CommentBlockInput`<br>• Set `resolved` on the returned object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| **`src/lib/github/client.ts`**                                                | *Where threads are grouped* (`_fetchPullCommentsLogic`) – determine `isResolved`:<br>`ts const resolved = commentsInThreadGroup.every(c => c.pull_request_review_id ? c.resolved : false); // see note below const threadBlock = makeThreadBlock(threadKey, path, line, diffHunk, individualCommentsData, resolved);`<br>**Note:** REST `listReviewComments` gives `pull_request_review_id` but **not** `resolved`. Cheapest option is **one extra call per thread**:<br>`ts const { data: threadMeta } = await octokit.request('GET /repos/{owner}/{repo}/pulls/comments/{comment_id}',{ … }); const resolved = threadMeta?.is_resolved === true;`<br>– Cache by `threadKey` to avoid N×M calls. |
| *(Optional)* move to GraphQL later for richer data without extra round-trips. |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |

---

### 2 — Dialog initial-state logic

| File                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Change |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
| **`PromptCopyDialog.tsx`**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |        |
| • **Types**: no change (already imports `PromptBlock`).<br>• **Mount effect** (where `selectedIds` & `openCollapsible` are initialised):<br>`ts const initSelected = new Set<string>();  const initOpen = {} as Record<string, boolean>; blocks.forEach(b => {   if (b.kind === 'comment' && b.threadId) {     const isResolved = b.resolved === true;     if (!isResolved) initSelected.add(b.id);     initOpen[b.id] = !isResolved; // open if unresolved   } else {     initSelected.add(b.id);     initOpen[b.id] = true;   } }); setSelectedIds(initSelected); setOpenCollapsible(initOpen);` |        |
| • **Checkbox tooltip**: when `block.resolved` → wrap check-box in `<Tooltip content="Thread is resolved"> … </Tooltip>` (only for code threads).                                                                                                                                                                                                                                                                                                                                                                                                                                                   |        |
| • **Styling**: optionally dim resolved header text via `.resolved { opacity: .6; }`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |        |

---

### 3 — UI affordances

* **Iconography:** keep existing Blueprint checkbox. Visual differentiation achieved via opacity + tooltip; future iterations could swap icon.
* **No runtime auto-update yet** – that’s Feature # 2.

---

### 4 — Unit tests

| Test file                   | Scenario                                                                            | Assertions                                                                                                                                               |
| --------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `PromptCopyDialog.test.tsx` | 1. Provide two thread blocks: one `resolved`, one `unresolved`.<br>2. Mount dialog. | • `selectedIds` initially has only the unresolved block.<br>• Collapsible arrow uses `openCollapsible[resolvedId] === false`.<br>• Tooltip text present. |
| `github/client.test.ts`     | Stub extra REST call, assert `resolved` flag set on `CommentBlockInput`.            |                                                                                                                                                          |